### PR TITLE
Fix Player Height/KKAPI/OverlayMod collision.

### DIFF
--- a/AI_UnlockPlayerHeight/Hooks.cs
+++ b/AI_UnlockPlayerHeight/Hooks.cs
@@ -97,12 +97,12 @@ namespace AI_UnlockPlayerHeight
 
         // Enable male height slider in charamaker //
         [HarmonyPostfix, HarmonyPatch(typeof(CustomControl), "Initialize")]
-        public static void CustomControl_Initialize_HeightPrefix(CustomControl __instance, byte _sex)
+        public static void CustomControl_Initialize_HeightPrefix(CustomControl __instance, byte _sex, UnityEngine.GameObject ___objSubCanvas)
         {
             if (_sex != 0)
                 return;
 
-            var comp = __instance.GetComponentInChildren<CvsB_ShapeWhole>();
+            var comp = ___objSubCanvas?.transform.Find("SettingWindow/WinBody").GetComponentInChildren<CvsB_ShapeWhole>();
             if (comp == null)
                 return;
 

--- a/HS2_UnlockPlayerHeight/Hooks.cs
+++ b/HS2_UnlockPlayerHeight/Hooks.cs
@@ -130,12 +130,12 @@ namespace HS2_UnlockPlayerHeight
 
         // Enable male height slider in charamaker //
         [HarmonyPostfix, HarmonyPatch(typeof(CustomControl), "Initialize")]
-        public static void CustomControl_Initialize_HeightPrefix(CustomControl __instance, byte _sex)
+        public static void CustomControl_Initialize_HeightPrefix(CustomControl __instance, byte _sex, UnityEngine.GameObject ___objSubCanvas)
         {
             if (_sex != 0)
                 return;
 
-            var comp = __instance.GetComponentInChildren<CvsB_ShapeWhole>();
+            var comp = ___objSubCanvas?.transform.Find("SettingWindow/WinBody").GetComponentInChildren<CvsB_ShapeWhole>();
             if (comp == null)
                 return;
 


### PR DESCRIPTION
KKAPI creates subcategories by cloning the B_ShapeWhole object but doesn't clear child components. Which includes CvsBShapeWhole.

OverlayMod adds a subcategory to the face tab which is earlier in the hierarchy then the actual body shape tab, so now this mod finds that instead of the intended target, cannot find the height slider there and exits. 

KKAPI not cleaning it's prototype cloned objects is likely the real issue, but for now making this more specific in what it is looking for solves the problem.